### PR TITLE
style: ajusta padding dos parágrafos da info-site para desktop

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -429,6 +429,9 @@ button:hover {
         margin: 32px auto;
         max-width: 1370px;
     }
+    .info-site .info-principal ~ p {
+        padding: 0 120px;
+    }
     .info-site h3 {
         font-size: 2.2em;
         margin: 20px 2px;


### PR DESCRIPTION
Este PR ajusta o padding dos parágrafos que ficam abaixo da div info-principal dentro da seção info-site, aplicando o estilo apenas para telas de desktop (min-width: 1024px). A alteração melhora a leitura e o espaçamento do conteúdo.